### PR TITLE
Fix Cloudflare geo mismatch when upstream proxy is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.1] - 2026-02-24
+
+- Fix incorrect Cloudflare geolocation when an upstream proxy sits before Cloudflare
+- In `:auto` mode, compare `CF-Connecting-IP` with the target IP and fall back to MaxMind on mismatch
+- Normalize compared IPs with `IPAddr` so equivalent IPv6 / IPv4-mapped forms are treated as matches
+- Add tests covering matching and mismatching `CF-Connecting-IP` scenarios
+
 ## [0.3.0] - 2026-02-08
 
 - Add 8 new geolocation fields: `region`, `region_code`, `continent`, `timezone`, `latitude`, `longitude`, `postal_code`, `metro_code`

--- a/lib/trackdown/providers/auto_provider.rb
+++ b/lib/trackdown/providers/auto_provider.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 require_relative 'base_provider'
 require_relative 'cloudflare_provider'
 require_relative 'maxmind_provider'
@@ -9,11 +11,19 @@ module Trackdown
     # Intelligent provider that automatically selects the best available provider
     # Priority order:
     # 1. Cloudflare (fastest, zero overhead, no external dependencies)
-    # 2. MaxMind (fallback when Cloudflare not available)
+    # 2. MaxMind (fallback when Cloudflare not available or IP mismatch)
     #
     # This is the recommended default for most applications
+    #
+    # IMPORTANT: When there's an upstream proxy before Cloudflare (e.g., a legacy
+    # API gateway), Cloudflare's geo headers will reflect the proxy's location,
+    # not the real client. AutoProvider detects this by comparing CF-Connecting-IP
+    # with the passed IP and falls back to MaxMind when they don't match.
     class AutoProvider < BaseProvider
+      CF_CONNECTING_IP_HEADER = 'HTTP_CF_CONNECTING_IP'
+
       @@warned_no_providers = false
+      @@warned_ip_mismatch = false
       @@warn_mutex = Mutex.new
 
       class << self
@@ -29,8 +39,16 @@ module Trackdown
         # @return [LocationResult] The location information
         def locate(ip, request: nil)
           # Try Cloudflare first - it's instant and free!
+          # But only if the IP matches what Cloudflare geolocated
           if CloudflareProvider.available?(request: request)
-            return CloudflareProvider.locate(ip, request: request)
+            if cloudflare_ip_matches?(ip, request)
+              return CloudflareProvider.locate(ip, request: request)
+            else
+              # IP mismatch: there's likely an upstream proxy before Cloudflare
+              # Cloudflare's geo headers are based on the proxy IP, not the real client
+              # Fall back to MaxMind with the correct IP
+              warn_ip_mismatch(ip, request)
+            end
           end
 
           # Fall back to MaxMind if available
@@ -44,6 +62,53 @@ module Trackdown
         end
 
         private
+
+        # Check if the IP we want to geolocate matches what Cloudflare saw as the client
+        # If they don't match, there's an upstream proxy and Cloudflare's geo headers are wrong
+        def cloudflare_ip_matches?(ip, request)
+          return true unless request # No request means we can't check
+
+          cf_connecting_ip = request.env[CF_CONNECTING_IP_HEADER]
+          return true if cf_connecting_ip.nil? || cf_connecting_ip.empty?
+
+          # Normalize IPs for comparison (handle IPv6 formatting differences)
+          normalize_ip(ip) == normalize_ip(cf_connecting_ip)
+        end
+
+        def normalize_ip(ip)
+          return nil if ip.nil?
+
+          value = ip.to_s.strip
+          return nil if value.empty?
+
+          parsed_ip = IPAddr.new(value)
+          parsed_ip = parsed_ip.native if parsed_ip.ipv4_mapped?
+          parsed_ip.to_s.downcase
+        rescue IPAddr::InvalidAddressError
+          # If parsing fails, fall back to string comparison so we still have
+          # deterministic behavior and can trigger MaxMind fallback on mismatch.
+          value.downcase
+        end
+
+        def warn_ip_mismatch(ip, request)
+          return if @@warned_ip_mismatch
+
+          @@warn_mutex.synchronize do
+            return if @@warned_ip_mismatch
+            @@warned_ip_mismatch = true
+
+            cf_ip = request&.env&.dig(CF_CONNECTING_IP_HEADER)
+            message = "[Trackdown] IP mismatch detected: request IP (#{ip}) differs from " \
+                      "CF-Connecting-IP (#{cf_ip}). This usually means there's an upstream " \
+                      "proxy before Cloudflare. Falling back to MaxMind for accurate geolocation."
+
+            if defined?(Rails)
+              Rails.logger.info(message)
+            else
+              warn(message)
+            end
+          end
+        end
 
         def warn_no_providers
           # Only warn once per process to avoid log spam

--- a/lib/trackdown/version.rb
+++ b/lib/trackdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Trackdown
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/test/support/mock_request.rb
+++ b/test/support/mock_request.rb
@@ -59,6 +59,31 @@ module TestHelpers
       request
     end
 
+    # Mock a request where the CF-Connecting-IP matches the IP we're geolocating
+    def mock_cloudflare_request_with_matching_ip(ip:, country: 'US', city: 'San Francisco')
+      request = Object.new
+      env = {
+        'HTTP_CF_IPCOUNTRY' => country,
+        'HTTP_CF_IPCITY' => city,
+        'HTTP_CF_CONNECTING_IP' => ip
+      }
+      request.define_singleton_method(:env) { env }
+      request
+    end
+
+    # Mock a request where CF-Connecting-IP differs from the IP we're geolocating
+    # This simulates an upstream proxy before Cloudflare
+    def mock_cloudflare_request_with_proxy(proxy_ip:, proxy_country: 'US', proxy_city: 'Ashburn')
+      request = Object.new
+      env = {
+        'HTTP_CF_IPCOUNTRY' => proxy_country,
+        'HTTP_CF_IPCITY' => proxy_city,
+        'HTTP_CF_CONNECTING_IP' => proxy_ip  # Cloudflare saw the proxy, not the client
+      }
+      request.define_singleton_method(:env) { env }
+      request
+    end
+
     def full_maxmind_record
       {
         'country' => {

--- a/test/trackdown/providers/auto_provider_test.rb
+++ b/test/trackdown/providers/auto_provider_test.rb
@@ -126,4 +126,114 @@ class AutoProviderTest < Minitest::Test
       assert_equal 'US', result.country_code
     end
   end
+
+  # --- IP Mismatch Detection Tests ---
+  # When there's an upstream proxy before Cloudflare, CF-Connecting-IP will contain
+  # the proxy's IP, not the real client. The geo headers will be wrong.
+
+  def test_uses_cloudflare_when_cf_connecting_ip_matches
+    # CF-Connecting-IP matches the IP we're looking up - Cloudflare headers are valid
+    client_ip = '104.255.87.245'
+    request = mock_cloudflare_request_with_matching_ip(ip: client_ip, country: 'GB', city: 'London')
+    cf_result = Trackdown::LocationResult.new('GB', 'United Kingdom', 'London', '🇬🇧')
+
+    Trackdown::Providers::CloudflareProvider.expects(:available?).with(request: request).returns(true)
+    Trackdown::Providers::CloudflareProvider.expects(:locate).with(client_ip, request: request).returns(cf_result)
+    Trackdown::Providers::MaxmindProvider.expects(:locate).never
+
+    result = Trackdown::Providers::AutoProvider.locate(client_ip, request: request)
+
+    assert_equal 'GB', result.country_code
+    assert_equal 'London', result.city
+  end
+
+  def test_uses_cloudflare_when_ipv6_formats_are_equivalent
+    # Same IPv6 address represented with different formatting.
+    client_ip = '2001:0db8:0000:0000:0000:0000:0000:0001'
+    request = Object.new
+    env = {
+      'HTTP_CF_IPCOUNTRY' => 'DE',
+      'HTTP_CF_IPCITY' => 'Berlin',
+      'HTTP_CF_CONNECTING_IP' => '2001:db8::1'
+    }
+    request.define_singleton_method(:env) { env }
+    cf_result = Trackdown::LocationResult.new('DE', 'Germany', 'Berlin', '🇩🇪')
+
+    Trackdown::Providers::CloudflareProvider.expects(:available?).with(request: request).returns(true)
+    Trackdown::Providers::CloudflareProvider.expects(:locate).with(client_ip, request: request).returns(cf_result)
+    Trackdown::Providers::MaxmindProvider.expects(:locate).never
+
+    result = Trackdown::Providers::AutoProvider.locate(client_ip, request: request)
+
+    assert_equal 'DE', result.country_code
+    assert_equal 'Berlin', result.city
+  end
+
+  def test_uses_cloudflare_when_ipv4_mapped_ipv6_matches
+    # Cloudflare may emit IPv4-mapped IPv6 in some network paths.
+    client_ip = '203.0.113.9'
+    request = Object.new
+    env = {
+      'HTTP_CF_IPCOUNTRY' => 'US',
+      'HTTP_CF_IPCITY' => 'Denver',
+      'HTTP_CF_CONNECTING_IP' => '::ffff:203.0.113.9'
+    }
+    request.define_singleton_method(:env) { env }
+    cf_result = Trackdown::LocationResult.new('US', 'United States', 'Denver', '🇺🇸')
+
+    Trackdown::Providers::CloudflareProvider.expects(:available?).with(request: request).returns(true)
+    Trackdown::Providers::CloudflareProvider.expects(:locate).with(client_ip, request: request).returns(cf_result)
+    Trackdown::Providers::MaxmindProvider.expects(:locate).never
+
+    result = Trackdown::Providers::AutoProvider.locate(client_ip, request: request)
+
+    assert_equal 'US', result.country_code
+    assert_equal 'Denver', result.city
+  end
+
+  def test_falls_back_to_maxmind_when_cf_connecting_ip_differs
+    # Simulates an upstream proxy before Cloudflare (e.g., rameerezapi)
+    # The real client is in India, but CF-Connecting-IP shows the proxy in Ashburn
+    client_ip = '104.255.87.245'  # Real client IP
+    proxy_ip = '34.204.24.48'     # Proxy's IP that Cloudflare saw (in Ashburn)
+
+    request = mock_cloudflare_request_with_proxy(
+      proxy_ip: proxy_ip,
+      proxy_country: 'US',
+      proxy_city: 'Ashburn'
+    )
+
+    # MaxMind should geolocate the real client IP correctly
+    maxmind_result = Trackdown::LocationResult.new('IN', 'India', 'Mumbai', '🇮🇳')
+    Trackdown.configuration.database_path = '/fake/path.mmdb'
+
+    File.stub :exist?, true do
+      Trackdown::Providers::CloudflareProvider.expects(:available?).with(request: request).returns(true)
+      # Cloudflare locate should NOT be called because IPs don't match
+      Trackdown::Providers::CloudflareProvider.expects(:locate).never
+      Trackdown::Providers::MaxmindProvider.expects(:available?).with(request: request).returns(true)
+      Trackdown::Providers::MaxmindProvider.expects(:locate).with(client_ip, request: request).returns(maxmind_result)
+
+      result = Trackdown::Providers::AutoProvider.locate(client_ip, request: request)
+
+      # Should return the correct location from MaxMind, not Ashburn from Cloudflare
+      assert_equal 'IN', result.country_code
+      assert_equal 'Mumbai', result.city
+    end
+  end
+
+  def test_uses_cloudflare_when_no_cf_connecting_ip_header
+    # If CF-Connecting-IP is not present, assume Cloudflare headers are valid
+    # (this is the legacy behavior for apps that don't have this header)
+    request = mock_cloudflare_request(country: 'DE', city: 'Berlin')
+    cf_result = Trackdown::LocationResult.new('DE', 'Germany', 'Berlin', '🇩🇪')
+
+    Trackdown::Providers::CloudflareProvider.expects(:available?).with(request: request).returns(true)
+    Trackdown::Providers::CloudflareProvider.expects(:locate).with('8.8.8.8', request: request).returns(cf_result)
+    Trackdown::Providers::MaxmindProvider.expects(:locate).never
+
+    result = Trackdown::Providers::AutoProvider.locate('8.8.8.8', request: request)
+
+    assert_equal 'DE', result.country_code
+  end
 end


### PR DESCRIPTION
## Summary
- detect upstream-proxy scenarios in `AutoProvider` by comparing target IP vs `CF-Connecting-IP`
- when they differ, skip Cloudflare geo headers and fall back to MaxMind for the real client IP
- normalize compared IPs with `IPAddr` so equivalent IPv6 / IPv4-mapped forms still match
- add focused tests for match/mismatch and IP normalization cases
- document release notes in changelog and bump version to `0.3.1`

## Why
When Cloudflare is behind another proxy, Cloudflare geo headers can reflect the proxy location (for example Ashburn) instead of the real client. `:auto` mode should avoid returning incorrect geo data in this case.

## Validation
- `bundle exec rake test` (203 runs, 459 assertions, 0 failures)
